### PR TITLE
Add basic debugging support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
     "name": "astra",
-    "image": "ghcr.io/ten-framework/astra_agents_build:0.4.0",
+    "image": "ghcr.io/ten-framework/astra_agents_build:0.5.1",
     "customizations": {
         "vscode": {
             "extensions": [
@@ -19,6 +19,7 @@
     ],
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/devcontainers/features/git:1": {}
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/python:1": {}
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,12 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
     "name": "astra",
-    "image": "ghcr.io/ten-framework/astra_agents_build:0.5.1",
+    "image": "ghcr.io/ten-framework/astra_agents_build:0.5.2",
     "customizations": {
         "vscode": {
             "extensions": [
-                "golang.go"
+                "golang.go",
+                "ms-vscode.cpptools"
             ]
         }
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "debug go",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/agents/bin/worker",
+            "env": {
+                "LD_LIBRARY_PATH": "${workspaceFolder}/agents/ten_packages/system/ten_runtime_go/lib:${workspaceFolder}/agents/ten_packages/system/agora_rtc_sdk/lib:${workspaceFolder}/agents/ten_packages/system/azure_speech_sdk/lib",
+                "TEN_APP_BASE_DIR": "${workspaceFolder}"
+            }
+        },
+        {
+            "name": "debug python",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "preLaunchTask": "start app"
+        },
+        {
+            "name": "debug cpp",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/agents/bin/worker",
+            "cwd": "${workspaceFolder}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/agents/ten_packages/system/agora_rtc_sdk/lib:${workspaceFolder}/agents/ten_packages/system/azure_speech_sdk/lib"
+                },
+                {
+                    "name": "CGO_LDFLAGS",
+                    "value": "-L${workspaceFolder}/agents/ten_packages/system/ten_runtime_go/lib -lten_runtime_go -Wl,-rpath,@loader_path/lib -Wl,-rpath,@loader_path/../lib"
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             "program": "${workspaceFolder}/agents/bin/worker",
             "env": {
                 "LD_LIBRARY_PATH": "${workspaceFolder}/agents/ten_packages/system/ten_runtime_go/lib:${workspaceFolder}/agents/ten_packages/system/agora_rtc_sdk/lib:${workspaceFolder}/agents/ten_packages/system/azure_speech_sdk/lib",
-                "TEN_APP_BASE_DIR": "${workspaceFolder}"
+                "TEN_APP_BASE_DIR": "${workspaceFolder}/agents"
             }
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"label": "build",
+			"command": "make build",
+			"args": [],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "start app",
+			"type": "shell",
+			"command": "export TEN_ENABLE_PYTHON_DEBUG=true; export TEN_PYTHON_DEBUG_PORT=5678; ./agents/bin/start",
+			"group": "none",
+			"isBackground": true
+		},
+	]
+}

--- a/agents/main.go
+++ b/agents/main.go
@@ -50,7 +50,6 @@ func startAppBlocking(cfg *appConfig) {
 
 	appInstance.Run(true)
 	appInstance.Wait()
-	ten.UnloadAllAddons()
 
 	ten.EnsureCleanupWhenProcessExit()
 }

--- a/agents/manifest-lock.json
+++ b/agents/manifest-lock.json
@@ -141,7 +141,8 @@
       "type": "system",
       "name": "nlohmann_json",
       "version": "3.11.2",
-      "hash": "72b15822c7ea9deef5e7ad96216ac55e93f11b00466dd1943afd5ee276e99d19"
+      "hash": "72b15822c7ea9deef5e7ad96216ac55e93f11b00466dd1943afd5ee276e99d19",
+      "supports": []
     },
     {
       "type": "system",

--- a/agents/manifest-lock.json
+++ b/agents/manifest-lock.json
@@ -1,10 +1,11 @@
 {
+  "version": 1,
   "packages": [
     {
       "type": "system",
       "name": "ten_runtime_go",
-      "version": "0.1.0",
-      "hash": "ab66a8ed40c744a52cce36f26a233e669d989d9f620876156e3cc7187f214977",
+      "version": "0.2.0",
+      "hash": "8b582de5dfaa38983104143fbb6c530b3aeb463ad9e9ef51f2c72fba9862b8cc",
       "dependencies": [
         {
           "type": "system",
@@ -21,8 +22,8 @@
     {
       "type": "extension",
       "name": "py_init_extension_cpp",
-      "version": "0.1.0",
-      "hash": "b39c4dddbec58e1a756b7e71f41ab0ec419ab0043525ba94e6ed98b7ef634697",
+      "version": "0.2.0",
+      "hash": "e1858dfd83d18a69901cefb2edfd52e57ee326a3d306e799ff1d661f3195bb6b",
       "dependencies": [
         {
           "type": "system",
@@ -43,8 +44,8 @@
     {
       "type": "extension_group",
       "name": "default_extension_group",
-      "version": "0.1.0",
-      "hash": "cfadaf8f951de42965e92becc67a597501196bc3bd6f17f39a64260836393c64",
+      "version": "0.2.0",
+      "hash": "117ed3e747654fc1282129a160eaecc2cd16548e70aa22128efee21f10e185c8",
       "dependencies": [
         {
           "type": "system",
@@ -61,8 +62,8 @@
     {
       "type": "extension",
       "name": "agora_rtc",
-      "version": "0.5.1",
-      "hash": "de8bb179155f6a329072be87ccd624177e9bbe795956a9a275e7886a3dc31cb7",
+      "version": "0.7.0-rc1",
+      "hash": "459eda37e62dd3e4012153a4a906192e4e68f2bc2210dd867d88f5fc008e73fd",
       "dependencies": [
         {
           "type": "system",
@@ -74,41 +75,9 @@
         },
         {
           "type": "system",
-          "name": "azure_speech_sdk"
-        },
-        {
-          "type": "system",
           "name": "nlohmann_json"
         }
       ],
-      "supports": [
-        {
-          "os": "linux",
-          "arch": "x64"
-        }
-      ]
-    },
-    {
-      "type": "extension",
-      "name": "azure_tts",
-      "version": "0.4.0",
-      "hash": "4f25e8c2a9c82f2a699a4e8378d11d2fbb31c90ec5df1718271ebfe6377a5389",
-      "dependencies": [
-        {
-          "type": "system",
-          "name": "ten_runtime"
-        },
-        {
-          "type": "system",
-          "name": "azure_speech_sdk"
-        }
-      ]
-    },
-    {
-      "type": "system",
-      "name": "ten_runtime",
-      "version": "0.1.0",
-      "hash": "b630f52ef9787132dc854fb4e90f962336be3f836baba137ca3b6dc132df0b86",
       "supports": [
         {
           "os": "linux",
@@ -129,10 +98,38 @@
       ]
     },
     {
+      "type": "extension",
+      "name": "azure_tts",
+      "version": "0.4.0",
+      "hash": "c8f838754aaae7ed4598e99fb94b6e251382ade08fa23dbf85e91e9864d018ef",
+      "dependencies": [
+        {
+          "type": "system",
+          "name": "ten_runtime"
+        },
+        {
+          "type": "system",
+          "name": "azure_speech_sdk"
+        }
+      ]
+    },
+    {
+      "type": "system",
+      "name": "ten_runtime",
+      "version": "0.2.0",
+      "hash": "7effdb036d5bf91894060a9230775ff8ec2598f202b8238578f99a14dbf11632",
+      "supports": [
+        {
+          "os": "linux",
+          "arch": "x64"
+        }
+      ]
+    },
+    {
       "type": "system",
       "name": "agora_rtc_sdk",
-      "version": "4.1.35+build328115",
-      "hash": "fd33989f9913d77e05970eb2b265fa5e08322141b7e0f8f9fd3e521f87929b3b",
+      "version": "4.1.36+build331418",
+      "hash": "74115dd35822dc3b09fbadb577b31146af704d60435ca401c0b305cce80b2ba4",
       "supports": [
         {
           "os": "linux",
@@ -149,8 +146,8 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1.0",
-      "hash": "a8980c39ba0cf1f21b38490c3167950f750403b1b29d756cfbacc5c5147becd7",
+      "version": "0.2.0",
+      "hash": "b44d3767f364583f8bb8e8995f6f7f49e3af27b3c9a8ddf62fa319f1fc39910e",
       "dependencies": [
         {
           "type": "system",

--- a/agents/manifest.json
+++ b/agents/manifest.json
@@ -6,22 +6,27 @@
     {
       "type": "system",
       "name": "ten_runtime_go",
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "type": "extension",
       "name": "py_init_extension_cpp",
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "type": "extension_group",
       "name": "default_extension_group",
-      "version": "0.1"
+      "version": "0.2"
     },
     {
       "type": "extension",
       "name": "agora_rtc",
-      "version": "=0.5.1"
+      "version": "=0.7.0-rc1"
+    },
+    {
+      "type": "system",
+      "name": "azure_speech_sdk",
+      "version": "1.38.0"
     },
     {
       "type": "extension",

--- a/agents/property.json
+++ b/agents/property.json
@@ -4,7 +4,7 @@
         "predefined_graphs": [
             {
                 "name": "va.openai.azure",
-                "auto_start": true,
+                "auto_start": false,
                 "nodes": [
                     {
                         "type": "extension",
@@ -1587,7 +1587,7 @@
             },
             {
                 "name": "va.gemini.azure",
-                "auto_start": true,
+                "auto_start": false,
                 "nodes": [
                     {
                         "type": "extension",
@@ -1786,7 +1786,7 @@
             },
             {
                 "name": "va.qwen.rag",
-                "auto_start": true,
+                "auto_start": false,
                 "nodes": [
                     {
                         "type": "extension",

--- a/agents/scripts/install_deps_and_build.sh
+++ b/agents/scripts/install_deps_and_build.sh
@@ -6,6 +6,9 @@ OS="linux"
 # x64, arm64
 CPU="x64"
 
+# debug, release
+BUILD_TYPE="release"
+
 build_cxx_extensions() {
   local app_dir=$1
 
@@ -16,8 +19,8 @@ build_cxx_extensions() {
 
   cp $app_dir/scripts/BUILD.gn $app_dir
 
-  tgn gen $OS $CPU release -- is_clang=false
-  tgn build $OS $CPU release
+  tgn gen $OS $CPU $BUILD_TYPE -- is_clang=false enable_sanitizer=false
+  tgn build $OS $CPU $BUILD_TYPE
 
   local ret=$?
 

--- a/agents/ten_packages/extension/aliyun_analyticdb_vector_storage/manifest.json
+++ b/agents/ten_packages/extension/aliyun_analyticdb_vector_storage/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/aliyun_text_embedding/manifest.json
+++ b/agents/ten_packages/extension/aliyun_text_embedding/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_python",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/azure_tts/manifest.json
+++ b/agents/ten_packages/extension/azure_tts/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime",
-            "version": "0.1"
+            "version": "0.2"
         },
         {
             "type": "system",

--- a/agents/ten_packages/extension/bedrock_llm_python/manifest.json
+++ b/agents/ten_packages/extension/bedrock_llm_python/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/chat_transcriber/manifest.json
+++ b/agents/ten_packages/extension/chat_transcriber/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_go",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/chat_transcriber_python/manifest.json
+++ b/agents/ten_packages/extension/chat_transcriber_python/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/cosy_tts/manifest.json
+++ b/agents/ten_packages/extension/cosy_tts/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_python",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/elevenlabs_tts/manifest.json
+++ b/agents/ten_packages/extension/elevenlabs_tts/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_go",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/elevenlabs_tts_python/manifest.json
+++ b/agents/ten_packages/extension/elevenlabs_tts_python/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_python",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/file_chunker/manifest.json
+++ b/agents/ten_packages/extension/file_chunker/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/gemini_llm_python/manifest.json
+++ b/agents/ten_packages/extension/gemini_llm_python/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_python",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/http_server_python/manifest.json
+++ b/agents/ten_packages/extension/http_server_python/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "package": {

--- a/agents/ten_packages/extension/interrupt_detector/manifest.json
+++ b/agents/ten_packages/extension/interrupt_detector/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_go",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/interrupt_detector_python/manifest.json
+++ b/agents/ten_packages/extension/interrupt_detector_python/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/llama_index_chat_engine/manifest.json
+++ b/agents/ten_packages/extension/llama_index_chat_engine/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/message_collector/manifest.json
+++ b/agents/ten_packages/extension/message_collector/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1.0"
+      "version": "0.2"
     }
   ],
   "package": {

--- a/agents/ten_packages/extension/openai_chatgpt/manifest.json
+++ b/agents/ten_packages/extension/openai_chatgpt/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_go",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/openai_chatgpt_python/manifest.json
+++ b/agents/ten_packages/extension/openai_chatgpt_python/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/polly_tts/manifest.json
+++ b/agents/ten_packages/extension/polly_tts/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_python",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {

--- a/agents/ten_packages/extension/qwen_llm_python/manifest.json
+++ b/agents/ten_packages/extension/qwen_llm_python/manifest.json
@@ -6,7 +6,7 @@
     {
       "type": "system",
       "name": "ten_runtime_python",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "api": {

--- a/agents/ten_packages/extension/transcribe_asr_python/manifest.json
+++ b/agents/ten_packages/extension/transcribe_asr_python/manifest.json
@@ -6,7 +6,7 @@
         {
             "type": "system",
             "name": "ten_runtime_python",
-            "version": "0.1"
+            "version": "0.2"
         }
     ],
     "api": {


### PR DESCRIPTION
- Upgrade TEN runtimes to `0.2`, build image to `0.5.2`
- Able to debug `go/python/cpp` **individually** via launch (refer to https://doc.theten.ai/ten-framework/debugging for more details as well as advanced usage)
  - set `BUILD_TYPE=debug` in `agents/scripts/install_deps_and_build.sh` for cpp debugging